### PR TITLE
Remove gap from CSP

### DIFF
--- a/admin-dashboard/index.html
+++ b/admin-dashboard/index.html
@@ -6,7 +6,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="theme-color" content="#2196f3">
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data:">
   <title>Framework7 Admin Dashboard</title>
   <link rel="stylesheet" href="https://unpkg.com/framework7/framework7-bundle.min.css">
   <link rel="stylesheet" href="https://unpkg.com/framework7-icons">

--- a/gmail-mobile/index.html
+++ b/gmail-mobile/index.html
@@ -7,7 +7,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="theme-color" content="#2196f3">
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data:">
 
   <title>GMail</title>
 

--- a/google-chrome-desktop/index.html
+++ b/google-chrome-desktop/index.html
@@ -6,7 +6,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="theme-color" content="#2196f3">
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data:">
   <title>Chrome</title>
   <link rel="stylesheet" href="https://unpkg.com/framework7/framework7-bundle.min.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">

--- a/macos-mail/index.html
+++ b/macos-mail/index.html
@@ -6,7 +6,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="theme-color" content="#2196f3">
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data:">
   <title>Mail</title>
   <link rel="stylesheet" href="https://unpkg.com/framework7/framework7-bundle.min.css">
   <link rel="stylesheet" href="https://unpkg.com/framework7-icons">

--- a/slack-desktop/index.html
+++ b/slack-desktop/index.html
@@ -6,7 +6,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="theme-color" content="#2196f3">
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data:">
   <title>Slack</title>
   <link rel="icon" href="https://cfr.slack-edge.com/cebaa/img/icons/favicon-32.png">
   <link rel="stylesheet" href="https://unpkg.com/framework7/framework7-bundle.min.css">

--- a/whatsapp-desktop/index.html
+++ b/whatsapp-desktop/index.html
@@ -7,7 +7,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="theme-color" content="#2196f3">
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data:">
   <title>Whatsapp</title>
   <link rel="icon" href="https://static.whatsapp.net/rsrc.php/v3/yP/r/rYZqPCBaG70.png">
   <link rel="stylesheet" href="https://unpkg.com/framework7/framework7-bundle.min.css">


### PR DESCRIPTION
In the recent release of Cordova CLI 11.0.0 the newest App Hello World template 6.0.0 is used for all new projects, in which the gap: (which was needed when using UIWebView on iOS) from the Content Security Policy has been completely removed.

So I thought of making the same change in framework7-recipes index.html files.